### PR TITLE
fix(ui): add tooltip and fix refresh icon rotation

### DIFF
--- a/components/SuggestionPanel.tsx
+++ b/components/SuggestionPanel.tsx
@@ -2,6 +2,12 @@
 
 import { motion } from 'framer-motion';
 import { RefreshCw, MessageCircle, Quote, Hash, Music } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 interface SuggestionPanelProps {
   suggestions: {
@@ -23,14 +29,28 @@ export function SuggestionPanel({ suggestions, mood, onRefresh }: SuggestionPane
         <h3 className="text-2xl font-bold text-gray-800">
           Personalized Insights
         </h3>
-        <motion.button
-          whileHover={{ scale: 1.05, rotate: 180 }}
-          whileTap={{ scale: 0.95 }}
-          onClick={onRefresh}
-          className="p-2 rounded-lg bg-white/70 backdrop-blur shadow-sm hover:shadow-md transition-all"
-        >
-          <RefreshCw className="w-5 h-5 text-purple-600" />
-        </motion.button>
+        <TooltipProvider delayDuration={500}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="px-2 pt-2 pb-[1px] rounded-lg bg-white/70 backdrop-blur shadow-sm hover:shadow-md transition-all">
+                <motion.button
+                  whileHover={{ scale: 1.05, rotate: 180 }}
+                  whileTap={{ scale: 0.95 }}
+                  onClick={onRefresh}
+                  className="transition-all"
+                >
+                  <RefreshCw className="w-5 text-purple-600" />
+                </motion.button>
+              </div>
+            </TooltipTrigger>
+
+            <TooltipContent
+              className="bg-white/80 backdrop-blur-md border-white/50 text-gray-800 shadow-xl"
+            >
+              <p>Refresh Insights</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
 
       {/* Journal Prompt */}


### PR DESCRIPTION
## 📝 Pull Request Summary
Added a descriptive "Refresh Insights" tooltip to the refresh button on the Emotion Detail Page (specifically in SuggestionPanel.tsx ).

This enhancement improves the user experience by clarifying the button's purpose without cluttering the UI. The tooltip implementation strictly adheres to the InnerHue aesthetic, utilizing glassmorphism (translucent background with blur) to maintain a premium, "Apple-level" feel.'

Also fixed the refresh button animation.
Earlier:  the background is also seen rotating along with the icon.
![inhue-issue-refresh](https://github.com/user-attachments/assets/618d1bf7-0280-47b9-81aa-45a654e0859c)



## 🔗 Related Issue
Solved : #10 

🛠️ Type of Change
 🎨 UI/UX Enhancement

Resolved: Fixed the animation and added the "Refresh Insights"
![inhue-issue-refresh-solved](https://github.com/user-attachments/assets/468f86f0-8f9a-4db7-9e13-49539eb74118)


## ✅ Contributor Checklist
- [x] I have tested my changes locally.
- [x] My code follows the Apple-level design guidelines (Glassmorphism & Smooth Animations).
- [x] (Apertre 3.0) I have added relevant badges/labels.


---
*By submitting this PR, I agree to contribute my work under the MIT License.*
