### PR TITLE
Floating emoji animation moved from Framer Motion to CSS

### DIFF
--- a/components/MoodCard.tsx
+++ b/components/MoodCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import './moodcard.css';
 
 interface Mood {
   id: string;
@@ -69,30 +70,15 @@ export function MoodCard({ mood, index, isSelected, onSelect }: MoodCardProps) {
           : '0 10px 30px rgba(0, 0, 0, 0.2), 0 5px 15px rgba(255, 255, 255, 0.1)'
       }}
     >
-      {/* Floating animation for emoji */}
-      <motion.div
-        animate={{
-          y: [0, -4, 0],
-          rotate: [0, 3, -3, 0],
-          scale: [1, 1.05, 1]
-        }}
-        transition={{
-          duration: 4 + Math.random() * 2,
-          repeat: Infinity,
-          ease: "easeInOut",
-          delay: index * 0.2
-        }}
-        className="text-center mb-2"
-      >
-        <motion.div 
-          className="text-3xl mb-1 filter drop-shadow-sm"
-          whileHover={{ scale: 1.2, rotate: 10 }}
-          transition={{ type: "spring", stiffness: 400 }}
-        >
+      {/* Floating emoji (ONLY CHANGE IS HERE) */}
+      <div className="text-center mb-2">
+        <div className="emoji-float text-3xl mb-1 filter drop-shadow-sm">
           {mood.emoji}
-        </motion.div>
-        <div className="text-sm font-medium text-gray-800 drop-shadow-sm">{mood.name}</div>
-      </motion.div>
+        </div>
+        <div className="text-sm font-medium text-gray-800 drop-shadow-sm">
+          {mood.name}
+        </div>
+      </div>
 
       {/* Glow effect */}
       {isSelected && (

--- a/components/moodcard.css
+++ b/components/moodcard.css
@@ -1,0 +1,10 @@
+@keyframes emoji-float {
+  0% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+  100% { transform: translateY(0); }
+}
+
+.emoji-float {
+  animation: emoji-float 2s ease-in-out infinite;
+  will-change: transform;
+}


### PR DESCRIPTION
## 📝 Pull Request Summary
optimizes animation performance by moving the continuous floating emoji animation from Framer Motion to a pure CSS animation
However Frames would affect and drop 

## 🔗 Related Issue
Part of #4 

## 🛠️ Type of Change
- [ ] 🚀 New Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [x] 🎨 UI/UX Enhancement

## 📸 Screenshots (If applicable)
*Add visual proof here*

## ✅ Contributor Checklist
- [x] I have tested my changes locally.
- [ ] My code follows the **Apple-level design** guidelines.
- [ ] I have updated the **README** if necessary.
- [ ] (Apertre 3.0) I have added relevant badges/labels.

---
*By submitting this PR, I agree to contribute my work under the MIT License.*
