### PR TITLE
fix: dynamic routing and stale state sync for mood detail page

### DIFF
--- a/app/mood/[id]/page.tsx
+++ b/app/mood/[id]/page.tsx
@@ -22,7 +22,11 @@ export default function MoodPage({ params, searchParams }: MoodPageProps) {
   const [suggestions, setSuggestions] = useState<any>(null);
   const [currentMoodIndex, setCurrentMoodIndex] = useState(0);
   
+  // Fix 1: Main Data Fetching & Index Reset
   useEffect(() => {
+    // 🔥 Reset index when route/params change
+    setCurrentMoodIndex(0);
+
     // Get all selected moods from query param, fallback to single mood from URL
     const moodIds = searchParams?.moods ? searchParams.moods.split(',') : [params.id];
     
@@ -33,11 +37,8 @@ export default function MoodPage({ params, searchParams }: MoodPageProps) {
     
     setMoodData(moodsData);
     
-    if (moodsData.length > 0) {
-      // Get suggestions for the first mood initially
-      const moodSuggestions = MoodData.getSuggestions(moodsData[0].id);
-      setSuggestions(moodSuggestions);
-    }
+    // Note: We removed the manual setSuggestions here. 
+    // The new useEffect below handles the initial suggestion load automatically.
     
     // Save to local storage for analytics
     const savedMoods = JSON.parse(localStorage.getItem('moodHistory') || '[]');
@@ -50,6 +51,17 @@ export default function MoodPage({ params, searchParams }: MoodPageProps) {
     });
     localStorage.setItem('moodHistory', JSON.stringify(savedMoods));
   }, [params.id, searchParams?.moods]);
+
+  // Fix 2: Sync suggestions automatically when Index or Data changes
+  useEffect(() => {
+    if (!moodData.length) return;
+
+    const mood = moodData[currentMoodIndex];
+    if (mood) {
+        const newSuggestions = MoodData.getSuggestions(mood.id);
+        setSuggestions(newSuggestions);
+    }
+  }, [currentMoodIndex, moodData]);
 
   if (!moodData.length || !suggestions) {
     return (
@@ -93,9 +105,8 @@ export default function MoodPage({ params, searchParams }: MoodPageProps) {
                     <motion.button
                       key={mood.id}
                       onClick={() => {
+                        // Logic simplified: The useEffect handles the suggestion sync
                         setCurrentMoodIndex(index);
-                        const newSuggestions = MoodData.getSuggestions(mood.id);
-                        setSuggestions(newSuggestions);
                       }}
                       whileHover={{ scale: 1.1 }}
                       whileTap={{ scale: 0.95 }}
@@ -157,7 +168,8 @@ export default function MoodPage({ params, searchParams }: MoodPageProps) {
               animate={{ opacity: 1, x: 0 }}
               transition={{ delay: 0.2 }}
             >
-              <OrbVisualizer mood={currentMood} />
+              {/* Fix 3: Added key prop to force re-render on mood change */}
+              <OrbVisualizer key={currentMood.id} mood={currentMood} />
             </motion.div>
 
             {/* Right Side - Suggestions */}


### PR DESCRIPTION
## 📝 Summary
Fixes stale UI and incorrect data when navigating between different mood detail pages.

## 🔧 Changes
- Reset currentMoodIndex when route/params change
- Sync suggestions automatically using useEffect
- Removed manual suggestion updates (single source of truth)
- Added key to OrbVisualizer to force proper re-render
- Prevents previous mood data leakage

## ✅ Result
- Correct mood loads on every navigation
- Orb color updates correctly
- Suggestions refresh correctly
- Back/Forward buttons work properly
- No hardcoded/default state

## 🔗 Related Issue
Closes #14

## 🛠️ Type
- [x] 🐛 Bug Fix

## ✅ Tested
- Navigated between multiple moods
- Browser back/forward
- Direct URL access
- Invalid id safe handling
☑ Bug Fix
☑ I have tested my changes locally
