### PR TITLE
 Footer Mood Selection link and scroll to mood section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -233,10 +233,11 @@ export default function Home() {
 
           {/* Mood Selection Grid */}
           <motion.div
+            id="mood-selection"
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.4 }}
-            className="text-center mb-8"
+            className="text-center mb-8 scroll-mt-24"
           >
             <h3 className="text-2xl md:text-3xl font-bold text-white mb-2">
               How are you feeling today?

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -26,7 +26,7 @@ export function Footer() {
                 </Link>
               </li>
               <li>
-                <Link href="/mood" className="hover:text-primary transition-colors">
+                <Link href="/#mood-selection" className="hover:text-primary transition-colors">
                   Mood Selection
                 </Link>
               </li>


### PR DESCRIPTION
Fixes #121

- Footer "Mood Selection" now links to `/#mood-selection` instead of `/mood` (404).
- Added `id="mood-selection"` and `scroll-mt-24` on the home page mood section so the link scrolls to the mood cards instead of the top.

https://github.com/user-attachments/assets/cfc67c26-768c-447b-801c-8ff78469ebc8

