### PR TITLE
refactor: Replace native confirm() with AlertDialog for Clear History

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { ArrowLeft, Calendar, Heart, Activity, Trash2 } from 'lucide-react';
@@ -8,16 +8,30 @@ import { MoodChart } from '@/components/MoodChart';
 import { BentoDashboard } from '@/components/BentoDashboard';
 import { useMoodStore } from '@/lib/useMoodStore';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 
 export default function AnalyticsPage() {
   const moodHistory = useMoodStore(state => state.moodHistory);
   const clearHistory = useMoodStore(state => state.clearHistory);
   const deleteMood = useMoodStore(state => state.deleteMood);
+  const [clearDialogOpen, setClearDialogOpen] = useState(false);
 
-  const handleClearHistory = () => {
-    if (confirm('Are you sure you want to clear your entire mood history?')) {
-      clearHistory();
-    }
+  const handleClearHistoryClick = () => {
+    setClearDialogOpen(true);
+  };
+
+  const handleConfirmClearHistory = () => {
+    clearHistory();
+    setClearDialogOpen(false);
   };
 
   const handleDeleteEntry = (id: string) => {
@@ -138,7 +152,7 @@ export default function AnalyticsPage() {
                   </div>
 
                   <button
-                    onClick={handleClearHistory}
+                    onClick={handleClearHistoryClick}
                     className="text-sm font-semibold 
                     px-4 py-1.5 rounded-full 
                     bg-red-50 dark:bg-red-900/20 
@@ -234,6 +248,31 @@ export default function AnalyticsPage() {
           )}
         </div>
       </main>
+
+      {/* Clear History confirmation modal */}
+      <AlertDialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
+        <AlertDialogContent className="max-w-md rounded-2xl border-white/20 dark:border-white/10 bg-white/95 dark:bg-[#1a1a35]/95 backdrop-blur-xl shadow-2xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-xl font-bold text-gray-800 dark:text-gray-100">
+              Clear mood history?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-gray-600 dark:text-gray-300">
+              Are you sure you want to clear your entire mood history? This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex flex-row gap-3 sm:gap-3 mt-6">
+            <AlertDialogCancel className="mt-0 rounded-xl border-gray-200 dark:border-white/20 bg-white dark:bg-white/10 hover:bg-gray-100 dark:hover:bg-white/20">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmClearHistory}
+              className="rounded-xl bg-red-500 hover:bg-red-600 text-white focus:ring-red-500/50"
+            >
+              Clear History
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
Replaces the browser’s native `confirm()` on the Analytics page with an in-app confirmation modal using Radix UI AlertDialog.

## Changes
- **Analytics page:** "Clear History" now opens an AlertDialog instead of calling `confirm()`.
- **Modal content:** Title "Clear mood history?", description that clearing cannot be undone, **Cancel** and **Clear History** actions.
- **Styling:** Modal uses the app’s design (backdrop blur, rounded corners, light/dark theme support). Cancel is outline-style; Clear History is a red destructive action.
- **Behavior:** Cancel closes the modal without clearing. Clear History runs the existing clear logic and closes the modal.
- Removed unused `useEffect` and `useCallback` imports from the analytics page.

## Testing
1. Go to Analytics with some mood history.
2. Click "Clear History".
3. Confirm the styled modal appears (no browser confirm).
4. Click Cancel → modal closes, history unchanged.
5. Click "Clear History" again, then confirm → history is cleared, modal closes.

https://github.com/user-attachments/assets/7ca1dd37-dbec-44f2-8f3c-d6bb6c6a7ed2



Fixes #128 

