### PR TITLE
 Add Open Graph and Twitter Card meta tags for link sharing

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,9 +9,24 @@ import { TransitionProvider } from '@/components/TransitionProvider';
 
 const inter = Inter({ subsets: ['latin'] });
 
+const siteTitle = 'InnerHue';
+const siteDescription = 'Emotional Reflection Web App';
+
 export const metadata: Metadata = {
-  title: 'InnerHue',
-  description: 'Emotional Reflection Web App',
+  title: siteTitle,
+  description: siteDescription,
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL ?? 'https://innerhue.vercel.app'),
+  openGraph: {
+    type: 'website',
+    title: siteTitle,
+    description: siteDescription,
+    siteName: siteTitle,
+  },
+  twitter: {
+    card: 'summary',
+    title: siteTitle,
+    description: siteDescription,
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
Adds Open Graph and Twitter Card metadata to the root layout so shared InnerHue links show a proper title and description on social platforms (Twitter, Facebook, LinkedIn, WhatsApp, etc.) instead of a generic preview.

## Changes
- **app/layout.tsx**
  - Introduced `siteTitle` and `siteDescription` and reused them for default metadata, Open Graph, and Twitter.
  - Set `metadataBase` for resolving relative URLs (uses `NEXT_PUBLIC_APP_URL` with a fallback).
  - **openGraph:** `type: 'website'`, `title`, `description`, `siteName`.
  - **twitter:** `card: 'summary'`, `title`, `description`.
- No new UI; metadata only. Image fields left out for now (can be added later with an asset in `public/`).

## Testing
- View page source (Ctrl+U) and search for `og:title` or `twitter:card` — meta tags should appear in `<head>`.
- After deploy, use [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) or share the link on Twitter/WhatsApp to confirm the preview shows the correct title and description.

## Screenshot
[Meta tags in page source]- 
<img width="1919" height="163" alt="Screenshot 2026-02-21 113531" src="https://github.com/user-attachments/assets/07bbf302-5998-4ae9-8e1c-cc8146570ab4" />
closes #142 