### PR TITLE
Fixed Footer section github button not redirecting to InnerHue github…

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -113,7 +113,7 @@ export function Footer() {
               </h3>
               <ul className="space-y-5">
                 {[
-                  { name: "GitHub", icon: Github, href: "https://github.com" },
+                  { name: "GitHub", icon: Github, href: "https://github.com/Nitya-003/InnerHue" },
                   { name: "LinkedIn", icon: Linkedin, href: "https://linkedin.com" },
                   { name: "Instagram", icon: Instagram, href: "https://instagram.com" },
                 ].map((item) => (


### PR DESCRIPTION
## 📝 Pull Request Summary
Fixed Footer section github button not redirecting to InnerHue github page

## 🔗 Related Issue
Closes #161 

## 🛠️ Type of Change
- [ ] 🚀 New Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 🎨 UI/UX Enhancement

## 📸 Screenshots (If applicable)

https://github.com/user-attachments/assets/410559e3-6347-4c2f-81ed-e00882b4ec64



## ✅ Contributor Checklist
- [x] I have tested my changes locally.
- [x] My code follows the **Apple-level design** guidelines.
- [x] I have updated the **README** if necessary.
- [ ] (Apertre 3.0) I have added relevant badges/labels.

---
@rishima17 plz review it
