### PR TITLE
fix(ui): remove duplicate inline hero section on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -169,56 +169,6 @@ export default function Home() {
       {/* Main Content */}
       <main className="relative z-10 px-4 md:px-6 pb-20">
         <div className="max-w-7xl mx-auto">
-          <motion.section
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2 }}
-            className="text-center py-12 md:py-16 lg:py-24 px-4"
-          >
-            <motion.div
-              initial={{ scale: 0.9, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              transition={{ delay: 0.3, duration: 0.8 }}
-              className="mb-6 sm:mb-8"
-            >
-              <h2 className="text-4xl sm:text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold text-white mb-4 sm:mb-6 drop-shadow-lg leading-tight">
-                Understand your emotions,{' '}
-                <span className="bg-gradient-to-r from-pink-400 to-purple-400 bg-clip-text text-transparent">
-                  one feeling at a time
-                </span>
-              </h2>
-
-              <p className="text-base sm:text-lg md:text-xl lg:text-2xl text-gray-200 max-w-3xl mx-auto drop-shadow leading-relaxed px-4">
-                Discover the depth of your emotional landscape with personalized insights,
-                therapeutic music, and guided reflection journeys tailored to your feelings.
-              </p>
-            </motion.div>
-
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.6 }}
-              className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center px-4"
-            >
-              <Link href="/emotions">
-                <motion.button
-                  whileHover={{ scale: 1.05, boxShadow: '0 20px 40px rgba(147, 51, 234, 0.4)' }}
-                  whileTap={{ scale: 0.95 }}
-                  className="w-full sm:w-auto px-6 sm:px-8 py-3 sm:py-4 bg-gradient-to-r from-purple-600 to-pink-600 text-white text-base sm:text-lg font-semibold rounded-full shadow-2xl hover:shadow-purple-500/50 transition-all duration-300 flex items-center justify-center gap-2 group"
-                >
-                  Start Reflecting
-                  <ArrowRight className="w-4 h-4 sm:w-5 sm:h-5 group-hover:translate-x-1 transition-transform" />
-                </motion.button>
-              </Link>
-
-              <motion.div
-                whileHover={{ scale: 1.05 }}
-                className="w-full sm:w-auto px-4 sm:px-6 py-3 sm:py-4 bg-white/10 backdrop-blur text-white rounded-full border border-white/30 hover:bg-white/20 transition-all duration-300 cursor-pointer text-center text-sm sm:text-base"
-              >
-                Learn More
-              </motion.div>
-            </motion.div>
-          </motion.section>
 
           {/* Mood Selection Grid */}
           <motion.div


### PR DESCRIPTION
Description
This PR addresses an issue on the homepage (/) where two nearly identical hero sections were unintentionally rendering on top of each other.

Root Cause: A merge artifact or leftover code caused the 

app/page.tsx
 file to render both the polished <Hero /> component (which includes the animated 3D orb and "Start Reflecting" functionality) and a duplicate inline block of JSX displaying the exact same "Understand your emotions..." heading below it.

Fix: Removed the duplicate inline hero section (lines 172–221) from 

app/page.tsx
. The page now cleanly transitions from the polished <Hero /> component straight into the "How are you feeling today?" mood selection grid.

Changes Made
Removed the redundant inline <motion.section> from 

app/page.tsx
.
Kept the primary <Hero /> component intact (

components/landing/Hero.tsx
 was unaffected).
Visual Impact
Before: Two different hero sections stacked on the homepage.
After: One single, unified hero section with the animated LandingOrb and clear CTA options.

Closes #187 

Preview

https://github.com/user-attachments/assets/784d4105-d262-4a0c-a3cb-dd279554976a

