### PR TITLE
Feat: Add optional reflection notes to mood entries

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -231,6 +231,11 @@ export default function AnalyticsPage() {
                           <div className="font-semibold text-gray-800 capitalize flex items-center">
                             {entry.emotion || entry.mood}
                           </div>
+                          {entry.notes && (
+                            <p className="text-sm text-gray-600 italic mt-1 max-w-sm line-clamp-2">
+                              "{entry.notes}"
+                            </p>
+                          )}
                           <div className="text-xs text-gray-500 font-medium">
                             {getTimeAgo(entry.timestamp)}
                           </div>


### PR DESCRIPTION
This PR introduces the ability for users to add personal notes or reflections alongside their mood logs. This enhances the emotional tracking experience by allowing users to capture specific thoughts and context for their feelings.

Key Changes
Store (

lib/useMoodStore.ts
):
Updated 

MoodEntry
 interface to include an optional notes field.
Added a new 

updateMoodNotes
 action to persist user reflections.
Modified 

addMood
 to return the entry ID for better UI tracking.
Mood Reflection UI (

components/SuggestionPanel.tsx
):
Integrated a "Reflection Notes" section with a soft-styled textarea.
Added a "Save Reflection" button with interactive success states.
View Logic (app/mood/[id]/page.tsx):
Updated to correctly handle route parameters and pass the active mood entry ID to the reflection panel.
Analytics (

app/analytics/page.tsx
):
Updated the History list to display saved notes directly under each mood entry.

<img width="1511" height="852" alt="image" src="https://github.com/user-attachments/assets/b3d9c9a2-602a-424d-a18d-64a3bca9ebdc" />

closes #190 