### PR TITLE
Learn more page leads to about page

### DIFF
--- a/app/landing/page.tsx
+++ b/app/landing/page.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import Link from "next/link";
+import LearnMoreButton from "@/components/LearnMoreButton";
 import {
   Heart,
   Brain,
@@ -126,12 +127,7 @@ export default function LandingPage() {
                 </motion.button>
               </Link>
 
-              <motion.div
-                whileHover={{ scale: 1.05 }}
-                className="px-6 py-4 bg-white/10 backdrop-blur text-white rounded-full border border-white/30 hover:bg-white/20 transition-all duration-300 cursor-pointer"
-              >
-                Learn More
-              </motion.div>
+              <LearnMoreButton className="px-6 py-4" />
             </motion.div>
           </motion.section>
 

--- a/app/mood/[id]/page.tsx
+++ b/app/mood/[id]/page.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { ArrowLeft } from 'lucide-react';
 import dynamic from 'next/dynamic';
+import type { OrbVisualizerProps } from '@/components/OrbVisualizer';
+import type { FC } from 'react';
 import { SuggestionPanel } from '@/components/SuggestionPanel';
 import { MoodData } from '@/lib/moodData';
 import { Mood, MoodSuggestion } from '@/types/mood';
@@ -15,9 +17,9 @@ import reflectiveMoods from '@/lib/reflectiveMoods';
 import { getTraditionalMoodId } from '@/lib/moodMapping';
 
 const OrbVisualizer = dynamic(
-  () => import('@/components/OrbVisualizer').then(m => m.OrbVisualizer),
+  () => import('@/components/OrbVisualizer').then((m) => ({ default: m.OrbVisualizer })),
   { ssr: false }
-);
+) as unknown as FC<OrbVisualizerProps>;
 
 interface MoodWithMeta extends Mood {
   traditionalId?: string;

--- a/components/LearnMoreButton.tsx
+++ b/components/LearnMoreButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+
+type Props = {
+  className?: string;
+  children?: React.ReactNode;
+};
+
+export default function LearnMoreButton({ className = "", children }: Props) {
+  return (
+    <Link href="/about">
+      <motion.button
+        whileHover={{ scale: 1.03 }}
+        whileTap={{ scale: 0.98 }}
+        className={
+          "px-6 py-3 bg-white/10 backdrop-blur text-white rounded-full border border-white/30 hover:bg-white/20 transition-all duration-300 " +
+          className
+        }
+      >
+        {children ?? "Learn More"}
+      </motion.button>
+    </Link>
+  );
+}

--- a/components/OrbVisualizer.tsx
+++ b/components/OrbVisualizer.tsx
@@ -3,16 +3,9 @@
 import { motion, Variants } from 'framer-motion';
 import { useState, useEffect, useRef } from 'react';
 import { ShaderOrb } from './ShaderOrb';
+import type { Mood } from '@/types/mood';
 
-interface Mood {
-  id: string;
-  name: string;
-  emoji: string;
-  color: string;
-  glow: string;
-}
-
-interface OrbVisualizerProps {
+export interface OrbVisualizerProps {
   mood: Mood;
 }
 
@@ -97,13 +90,15 @@ export function OrbVisualizer({ mood }: OrbVisualizerProps) {
   const [particles, setParticles] = useState<{ id: number; angle: number; distance: number; duration: number }[]>([]);
 
   useEffect(() => {
-    setParticles(Array.from({ length: 12 }, (_, i) => ({
-      id: i,
-      angle: (i * 30) * (Math.PI / 180),
-      distance: 150 + Math.random() * 50,
-      duration: 3 + Math.random() * 2
-    }))
-  );
+    setParticles(
+      Array.from({ length: 12 }, (_, i) => ({
+        id: i,
+        angle: (i * 30) * (Math.PI / 180),
+        distance: 150 + Math.random() * 50,
+        duration: 3 + Math.random() * 2,
+      }))
+    );
+  }, []);
 
   return (
     <div className="relative">

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -1,9 +1,10 @@
-'use client';
+"use client";
 
 import { motion } from 'framer-motion';
 import { ArrowRight, Sparkles } from 'lucide-react';
 import { LandingOrb } from './LandingOrb';
 import { useRouter } from 'next/navigation';
+import LearnMoreButton from '@/components/LearnMoreButton';
 
 export function Hero() {
   const router = useRouter();
@@ -91,7 +92,7 @@ export function Hero() {
         </motion.div>
 
         {/* Primary CTA Button - Glassmorphic Style with Custom Transition */}
-        <motion.div variants={itemVariants}>
+        <motion.div variants={itemVariants} className="flex flex-col sm:flex-row items-center gap-4 justify-center">
           <motion.button
             onClick={() => router.push('/explore')}
             whileHover={{
@@ -151,6 +152,8 @@ export function Hero() {
               <ArrowRight className="w-5 h-5 sm:w-6 sm:h-6" />
             </motion.span>
           </motion.button>
+
+          <LearnMoreButton />
         </motion.div>
 
         {/* Secondary text */}


### PR DESCRIPTION
## 📝 Pull Request Summary
The learn more button in the home page leads to about page and is not a dummy button anymore

## 🔗 Related Issue
Closes #167 

## 🛠️ Type of Change
- [ ] 🚀 New Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 🎨 UI/UX Enhancement

## 📸 Screenshots (If applicable)
https://jumpshare.com/s/JWOj0DjRjoxToJhcTXAn 

## ✅ Contributor Checklist
- [x] I have tested my changes locally.
- [ ] My code follows the **Apple-level design** guidelines.
- [ ] I have updated the **README** if necessary.
- [x] (Apertre 3.0) I have added relevant badges/labels.

---
*By submitting this PR, I agree to contribute my work under the MIT License.*
