### PR TITLE
feat: persist selected moods across page refresh using localStorage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,6 +65,16 @@ interface Orb {
 
 export default function Home() {
   const [selectedMoods, setSelectedMoods] = useState<string[]>([]);
+  useEffect(() => {
+  const savedMoods = localStorage.getItem("selectedMoods");
+  if (savedMoods) {
+    setSelectedMoods(JSON.parse(savedMoods));
+  }
+}, []);
+  useEffect(() => {
+  localStorage.setItem("selectedMoods", JSON.stringify(selectedMoods));
+}, [selectedMoods]);
+
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<boolean>(false);
   const maxSelections = 3;


### PR DESCRIPTION
### Description
This PR adds persistence for selected moods using localStorage so that the user's selected mood remains highlighted even after refreshing the page.

### Changes
- Load saved moods from localStorage on page load
- Store selected moods in localStorage whenever the selection changes
- Ensures better continuity in the reflection experience

### Issue
Closes #222