### PR TITLE
Fix/quote error handling

### DIFF
--- a/lib/getQuote.ts
+++ b/lib/getQuote.ts
@@ -32,6 +32,15 @@ export const getQuoteByMood = async (tag: string): Promise<Quote> => {
     // If no specific tag match, use any quote
     const pool = relevantQuotes.length > 0 ? relevantQuotes : fallbackQuotes;
 
+    // Ensure we have a valid fallback quote
+    if (pool.length === 0) {
+      return {
+        content: "You're stronger than you think.",
+        author: "InnerHue",
+        tags: [tag]
+      };
+    }
+
     return pool[Math.floor(Math.random() * pool.length)];
   }
 };


### PR DESCRIPTION
Changes made:
Added validation to ensure the fallback quote pool is not empty before attempting to return a random quote
If both relevantQuotes and fallbackQuotes are empty, the function now returns a hardcoded safe quote instead of undefined
Regarding lib/moodData.ts:
The issue description referenced code at lines 773-814 that doesn't exist in the current file (the file is only 668 lines). The methods mentioned (getAllMoods, custom mood storage with any types) are not present in the codebase. The existing implementation in moodData.ts is already type-safe with proper TypeScript interfaces.
closes #217 closes #234 