### PR TITLE
fix(signup): fix label-input association and email input type for acc…

### DIFF
--- a/components/signupform.tsx
+++ b/components/signupform.tsx
@@ -56,8 +56,9 @@ export default function SignupForm() {
 
       {/* Name */}
       <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium text-foreground/80 dark:text-white/80">Full Name</label>
+        <label htmlFor="name" className="text-sm font-medium text-foreground/80 dark:text-white/80">Full Name</label>
         <input
+         id="name"
           {...register("name")}
           className="bg-background/80 dark:bg-black/20 border border-border dark:border-white/10 p-3 rounded-lg text-foreground dark:text-white placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
           placeholder="Aditya Patra"
@@ -67,8 +68,10 @@ export default function SignupForm() {
 
       {/* Email */}
       <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium text-foreground/80 dark:text-white/80">Email</label>
+        <label htmlFor="email" className="text-sm font-medium text-foreground/80 dark:text-white/80">Email</label>
         <input
+        id="email"
+        type="email"
           {...register("email")}
           className="bg-background/80 dark:bg-black/20 border border-border dark:border-white/10 p-3 rounded-lg text-foreground dark:text-white placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
           placeholder="you@example.com"
@@ -78,8 +81,9 @@ export default function SignupForm() {
 
       {/* Password */}
       <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium text-foreground/80 dark:text-white/80">Password</label>
+        <label htmlFor="password" className="text-sm font-medium text-foreground/80 dark:text-white/80">Password</label>
         <input
+          id="password"
           type="password"
           {...register("password")}
           className="bg-background/80 dark:bg-black/20 border border-border dark:border-white/10 p-3 rounded-lg text-foreground dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"
@@ -89,8 +93,9 @@ export default function SignupForm() {
 
       {/* Confirm Password */}
       <div className="flex flex-col gap-2">
-        <label className="text-sm font-medium text-foreground/80 dark:text-white/80">Confirm Password</label>
+        <label htmlFor="confirmPassword" className="text-sm font-medium text-foreground/80 dark:text-white/80">Confirm Password</label>
         <input
+          id="confirmPassword"
           type="password"
           {...register("confirmPassword")}
           className="bg-background/80 dark:bg-black/20 border border-border dark:border-white/10 p-3 rounded-lg text-foreground dark:text-white focus:outline-none focus:ring-2 focus:ring-purple-500"


### PR DESCRIPTION
Fixes #278

## Problem

The signup form had two accessibility and UX issues:
- `<label>` elements had no `htmlFor` and `<input>` elements had no matching `id`, so screen readers couldn't associate them properly and clicking a label didn't focus the input
- The email input was missing `type="email"`, so it didn't get mobile keyboard optimization or browser-level validation

## Changes Made

### Full Name Field
**Before:**
```tsx
<label className="...">Full Name</label>
<input
  {...register("name")}
  className="..."
  placeholder="Aditya Patra"
/>
```
**After:**
```tsx
<label htmlFor="name" className="...">Full Name</label>
<input
  id="name"
  {...register("name")}
  className="..."
  placeholder="Aditya Patra"
/>
```

### Email Field
**Before:**
```tsx
<label className="...">Email</label>
<input
  {...register("email")}
  className="..."
  placeholder="you@example.com"
/>
```
**After:**
```tsx
<label htmlFor="email" className="...">Email</label>
<input
  id="email"
  type="email"
  {...register("email")}
  className="..."
  placeholder="you@example.com"
/>
```

### Password Field (Bonus Fix)
**Before:**
```tsx
<label className="...">Password</label>
<input
  type="password"
  {...register("password")}
  className="..."
/>
```
**After:**
```tsx
<label htmlFor="password" className="...">Password</label>
<input
  id="password"
  type="password"
  {...register("password")}
  className="..."
/>
```

### Confirm Password Field (Bonus Fix)
**Before:**
```tsx
<label className="...">Confirm Password</label>
<input
  type="password"
  {...register("confirmPassword")}
  className="..."
/>
```
**After:**
```tsx
<label htmlFor="confirmPassword" className="...">Confirm Password</label>
<input
  id="confirmPassword"
  type="password"
  {...register("confirmPassword")}
  className="..."
/>
```

## Why This Matters

- Screen readers can now properly announce which label belongs to which field
- Clicking any label now focuses the corresponding input
- Email field now triggers the correct keyboard layout on mobile
- Adds browser-level email validation before Zod runs

## Type of Change

- [x] Bug fix
- [x] Accessibility / UX improvement