### PR TITLE
fix: add iframe title and fix setTimeout memory leak in SuggestionPanel

### DIFF
--- a/components/SuggestionPanel.tsx
+++ b/components/SuggestionPanel.tsx
@@ -53,14 +53,19 @@ export function SuggestionPanel({
     }
   }, [entryId, moodHistory]);
 
-  const handleSaveNotes = () => {
-    if (!entryId) return;
-    setIsSaving(true);
-    updateMoodNotes(entryId, notes);
-    setTimeout(() => {
-      setIsSaving(false);
-    }, 1000);
-  };
+useEffect(() => {
+  if (!isSaving) return;
+  const timer = setTimeout(() => {
+    setIsSaving(false);
+  }, 1000);
+  return () => clearTimeout(timer);  //  cleanup on unmount
+}, [isSaving]);
+
+const handleSaveNotes = () => {
+  if (!entryId) return;
+  updateMoodNotes(entryId, notes);
+  setIsSaving(true);
+};
 
   const [isPlayerLoaded, setIsPlayerLoaded] = useState(false);
 
@@ -168,6 +173,7 @@ export function SuggestionPanel({
                   </div>
                 )}
                 <iframe
+                  title="Spotify Soundscape Player"
                   src={`https://open.spotify.com/embed/playlist/${mood.spotifyPlaylistId || '37i9dQZF1DX3Ogo9pFno96'}?utm_source=generator&theme=0`}
                   width="100%"
                   height="152"


### PR DESCRIPTION
## Summary

Fixed two issues in `SuggestionPanel.tsx` related to accessibility 
and memory leak.


## Changes

### Bug 1 — Added title to Spotify iframe

Spotify `<iframe>` was missing a `title` attribute. Screen readers 
could not describe what the iframe contains to visually impaired users.

Added `title="Spotify Soundscape Player"` to the iframe.

### Bug 2 — Fixed setTimeout memory leak in handleSaveNotes

`setTimeout` inside `handleSaveNotes` was never cleared. If user 
navigates away before 1 second, component unmounts but timeout still 
fires and tries to update state on unmounted component.

Moved setTimeout into a `useEffect` with proper cleanup using 
`clearTimeout` on unmount.


## Files Changed

- `SuggestionPanel.tsx`



## Testing

- Lighthouse accessibility score no longer flags missing iframe title
- Screen readers can now correctly describe the Spotify player
- No React warning about state update on unmounted component
- Saving notes and navigating away immediately no longer causes memory leak



Fixes #283