### PR TITLE
fix(storage): replace direct localStorage calls with useLocalStorage hook in home page

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -23,6 +23,7 @@ import AITherapist from "@/components/AITherapist";
 import { ErrorState } from "@/components/ErrorState";
 import { SkeletonMoodCard } from "@/components/SkeletonMoodCard";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 
 const moods = [
   {
@@ -294,17 +295,7 @@ interface Orb {
 }
 
 export default function Home() {
-  const [selectedMoods, setSelectedMoods] = useState<string[]>([]);
-  useEffect(() => {
-  const savedMoods = localStorage.getItem("selectedMoods");
-  if (savedMoods) {
-    setSelectedMoods(JSON.parse(savedMoods));
-  }
-}, []);
-  useEffect(() => {
-  localStorage.setItem("selectedMoods", JSON.stringify(selectedMoods));
-}, [selectedMoods]);
-
+  const [selectedMoods, setSelectedMoods] = useLocalStorage<string[]>('selectedMoods', []);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<boolean>(false);
   const [, setOrbs] = useState<{ id: number; color: string; width: number; height: number; left: number; top: number; x: number; y: number; duration: number }[]>([]);


### PR DESCRIPTION
Closes #294

## What This PR Does

Replaces raw localStorage.getItem/setItem calls in app/page.tsx with theestablished useLocalStorage hook for managing selectedMoods state.

## Root Cause

selectedMoods was being read and written via direct localStorage calls, bypassing the `local-storage-update` custom event that the useLocalStorage hook dispatches on every write. Other components listening for that event would receive stale mood data without a full page reload, risking inconsistent UI state across the app.

## Changes Made

- Removed two useEffect blocks handling manual localStorage read/write
- Removed the useState<string[]>([]) declaration for selectedMoods
- Replaced all three with a single useLocalStorage<string[]>('selectedMoods', []) call
- Added import for useLocalStorage from @/hooks/useLocalStorage

## Testing

- Selected moods on home page → refreshed the page → moods remained selected 
- local-storage-update event now fires correctly on mood selection 
- No TypeScript errors 
- No console errors 

## Why This Matters

The useLocalStorage hook is the established data access pattern in this codebase — it handles SSR safety, error boundaries, and cross-component synchronization via custom events. Direct localStorage access bypasses all of this, making the app fragile and harder to maintain as more components depend on shared state.