### PR TITLE
fix(storage): prevent hydration mismatch from uselocalstorage in home page.

### DIFF
--- a/frontend/app/api/analytics/route.ts
+++ b/frontend/app/api/analytics/route.ts
@@ -69,8 +69,9 @@ export async function GET(request: Request) {
     };
 
     return NextResponse.json(stats);
-  } catch (error: any) {
-    console.error('Analytics API Error:', error);
-    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
-  }
+  } catch (error: unknown) {
+  const message = error instanceof Error ? error.message : 'Internal Server Error';
+  console.error('Analytics API Error:', message);
+  return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+}
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -296,6 +296,12 @@ interface Orb {
 
 export default function Home() {
   const [selectedMoods, setSelectedMoods] = useLocalStorage<string[]>('selectedMoods', []);
+  const [isMounted, setIsMounted] = useState(false);
+
+useEffect(() => {
+  setIsMounted(true);
+}, []);
+
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<boolean>(false);
   const [, setOrbs] = useState<{ id: number; color: string; width: number; height: number; left: number; top: number; x: number; y: number; duration: number }[]>([]);
@@ -460,7 +466,7 @@ export default function Home() {
     key={mood.id}
     mood={mood}
     index={index}
-    isSelected={selectedMoods.includes(mood.id)}
+    isSelected={isMounted && selectedMoods.includes(mood.id)}
     onSelect={() => {
       setSelectedMoods((prev) => {
         if (prev.includes(mood.id)) {

--- a/frontend/components/LoginForm.tsx
+++ b/frontend/components/LoginForm.tsx
@@ -35,11 +35,12 @@ export default function LoginForm() {
       });
       
       router.push("/"); // Redirect to home/dashboard
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Please check your email and password.";
       toast.dismiss(toastId);
       toast.error("Login failed", {
-        description: error.message || "Please check your email and password.",
-      });
+        description: message,
+  });
     
     }
   };

--- a/frontend/components/signupform.tsx
+++ b/frontend/components/signupform.tsx
@@ -41,12 +41,13 @@ export default function SignupForm() {
       });
       
       router.push("/");
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Something went wrong.";
       toast.dismiss(toastId);
-      setServerError(error.message || "Something went wrong.");
+      setServerError(message);
       toast.error("Signup failed", {
-        description: error.message || "Please try again.",
-      });
+       description: message,
+  });
     }
   };
 

--- a/frontend/lib/getChatReply.ts
+++ b/frontend/lib/getChatReply.ts
@@ -28,9 +28,9 @@ export async function getChatReply(
         return data.reply;
       }
     }
-  } catch (e) {
-    if (e instanceof Error && e.name === 'AbortError') {
-      throw e;
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error;
     }
     // network / 404 on static hosting
   }


### PR DESCRIPTION
Closes #302 

## What This PR Does

Replaces raw `localStorage.getItem/setItem` calls in app/page.tsx with the established useLocalStorage hook for selectedMoods, and fixes the resulting SSR hydration mismatch on MoodCard.

## Root Cause

selectedMoods was read and written via direct localStorage calls, bypassing the local-storage-update custom event that useLocalStorage dispatches on every write. After switching to the hook, a hydration mismatch appeared because
the server renders selectedMoods as `[]` while the client immediately reads saved moods from localStorage — causing aria-pressed to differ between server and client renders on MoodCard.

## Changes Made

- Removed two useEffect blocks handling manual localStorage read/write
- Removed useState<string[]>([]) declaration for selectedMoods
- Replaced with single useLocalStorage<string[]>(selectedMoods, []) call
- Added isMounted state guard to defer isSelected until after hydration
- Changed isSelected={selectedMoods.includes(mood.id)} to isSelected={isMounted && selectedMoods.includes(mood.id)}
- Added import for useLocalStorage from @/hooks/useLocalStorage

## Testing

- Selected moods → refreshed page → moods still selected 
- No hydration mismatch errors in console 
- aria-pressed renders correctly after hydration 
- No TypeScript errors 

## Why This Matters

The useLocalStorage hook is the established data access pattern in this codebase — it handles SSR safety, error boundaries, and cross-component synchronization via custom events. Direct localStorage access bypasses all of this, making the app fragile and harder to maintain as more components depend on shared state.