### PR TITLE
add Escape key handler to StreakDetailModal

### DIFF
--- a/frontend/components/StreakCard.tsx
+++ b/frontend/components/StreakCard.tsx
@@ -104,6 +104,17 @@ function StreakDetailModal({
         const nudgeList = generateNudges(streakData, logged);
         setNudges(nudgeList);
     }, [streakData]);
+    useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+            onClose();
+        }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+    };
+    }, [onClose]);   
 
     const handleDismissNudge = () => {
         dismissNudge();


### PR DESCRIPTION

Closes #301

##  Description
`StreakDetailModal` in `StreakCard.tsx` had no keyboard support — users could not close the modal using the `Escape` key, which is a standard UX expectation for modals.

##  Problem
Modal could only be closed by:
- Clicking the backdrop
- Clicking the ✕ button

Keyboard-only users and accessibility users had no way to dismiss the modal.

## ✅ Fix
Added a `useEffect` inside `StreakDetailModal` that:
- Listens for `keydown` events on the document
- Calls `onClose()` when the `Escape` key is pressed
- Properly cleans up the event listener on component unmount

## 🔧 Changes Made
| File | Change |
|------|--------|
| `StreakCard.tsx` | Added `useEffect` with Escape key handler inside `StreakDetailModal` |

##  Code Added
```tsx
useEffect(() => {
    const handleKeyDown = (e: KeyboardEvent) => {
        if (e.key === 'Escape') {
            onClose();
        }
    };
    document.addEventListener('keydown', handleKeyDown);
    return () => {
        document.removeEventListener('keydown', handleKeyDown);
    };
}, [onClose]);
```

##  Testing
- [x] Modal closes when `Escape` key is pressed
- [x] Modal still closes on backdrop click
- [x] Modal still closes on ✕ button click
- [x] Event listener is cleaned up on modal unmount
- [x] No other functionality affected

## 📌 Notes
- No backend changes required
- No new dependencies added
- `useEffect` was already imported — no import changes needed