### PR TITLE
fix: reset isTransitioning state and prevent double-click in

### DIFF
--- a/frontend/components/TransitionLink.tsx
+++ b/frontend/components/TransitionLink.tsx
@@ -19,6 +19,7 @@ export function TransitionLink({ href, children, className = '', onClick }: Tran
 
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
+    if (isTransitioning) return;
     
     // Get click position for ripple effect
     const rect = e.currentTarget.getBoundingClientRect();
@@ -33,6 +34,7 @@ export function TransitionLink({ href, children, className = '', onClick }: Tran
     // Small delay for visual feedback before navigation
     setTimeout(() => {
       router.push(href);
+      setIsTransitioning(false);
     }, 150);
   };
 


### PR DESCRIPTION

Closes #299

##  Description
Two bugs were found in `TransitionLink.tsx` affecting navigation behavior and component state management.
Both fixes are in the same `handleClick` function — resolved in a single PR with minimal changes.

##  Problems

### Issue 1 — `isTransitioning` State Never Resets to `false`
Once the user clicked the link, `isTransitioning` was set to `true` but never reset back to `false` after navigation completed.
- Ripple effect wouldn't work again if user returned to the same page
- Component stayed in wrong state permanently after first click

### Issue 2 — No Double Click Protection
No guard existed in `handleClick` — rapid clicking triggered multiple `router.push()` calls simultaneously.
- Multiple `router.push()` calls on rapid clicking
- Unpredictable navigation behavior
- Poor user experience

## ✅ Fix

### Issue 1 Fix — Reset `isTransitioning` after navigation
```tsx
setTimeout(() => {
  router.push(href);
  setIsTransitioning(false); //  resets after navigation
}, 150);
```

### Issue 2 Fix — Block subsequent clicks while navigating
```tsx
const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
  e.preventDefault();
  if (isTransitioning) return; //  blocks double click
  ...
};
```

## 🔧 Changes Made
| File | Change |
|------|--------|
| `TransitionLink.tsx` | Added double-click guard in `handleClick` |
| `TransitionLink.tsx` | Added `setIsTransitioning(false)` after `router.push()` |

##  Testing
- [x] Ripple effect works correctly on repeated clicks
- [x] `isTransitioning` resets to `false` after navigation completes
- [x] Rapid clicking no longer triggers multiple `router.push()` calls
- [x] Normal single click navigation works as expected
- [x] No other functionality affected

## 📌 Notes
- No backend changes required
- No new dependencies added
- Both fixes are in the same `handleClick` function — single PR covers both issues