### PR TITLE
feat(backend): add rate limiting middleware to prevent  API abuse

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "helmet": "^8.2.0",
     "morgan": "^1.11.0"
   }

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
 import { errorHandler } from './middleware/errorHandler.js';
+import { generalLimiter, chatLimiter, analyticsLimiter } from './middleware/rateLimiter.js';
 import healthRouter from './routes/health.js';
 import moodsRouter from './routes/moods.js';
 import analyticsRouter from './routes/analytics.js';
@@ -22,9 +23,11 @@ app.use(morgan('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+app.use(generalLimiter);
+
 app.use('/health', healthRouter);
 app.use('/api/moods', moodsRouter);
-app.use('/api/analytics', analyticsRouter);
+app.use('/api/analytics', analyticsLimiter, analyticsRouter);
 
 app.use((req, res) => {
   res.status(404).json({ error: `Route ${req.method} ${req.path} not found` });

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -1,0 +1,32 @@
+import rateLimit from 'express-rate-limit';
+
+export const generalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: 'Too many requests, please try again later.',
+  },
+});
+
+
+export const chatLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: 'Chat rate limit exceeded, please wait before sending more messages.',
+  },
+});
+
+export const analyticsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    error: 'Analytics rate limit exceeded, please try again later.',
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,10 @@
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0",
         "morgan": "^1.11.0"
-      },
-      "devDependencies": {}
+      }
     },
     "frontend": {
       "name": "nextjs",
@@ -9579,6 +9579,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -11303,6 +11321,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {


### PR DESCRIPTION
Closes #304 

## What This PR Does

Adds rate limiting middleware to the Express backend using express-rate-limit to prevent API abuse and protect future AI provider endpoints from excessive requests.

## Root Cause

The backend had no request throttling on any endpoint. The /api/chat endpoint in particular will call an external AI provider on every request — without rate limiting, a single client could exhaust API credits or cause denial of service.

## Changes Made

- Installed express-rate-limit dependency
- Created `backend/src/middleware/rateLimiter.js` with three limiters:
  - generalLimiter — 100 req/15min applied to all routes
  - analyticsLimiter`— 30 req/15min on `/api/analytics`
  - chatLimiter — 20 req/15min on `/api/chat` (ready for when route is added)
- Updated `backend/src/app.js` to apply limiters to appropriate routes
- Rate limit headers returned via RFC-compliant standardHeaders mode:
  RateLimit-Policy, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset

## Testing

```bash
curl -I http://localhost:3001/health
# RateLimit-Policy: 100;w=900
# RateLimit-Limit: 100
# RateLimit-Remaining: 99

curl -I http://localhost:3001/api/analytics
# RateLimit-Policy: 30;w=900
# RateLimit-Limit: 30
# RateLimit-Remaining: 29
```

## Why This Matters

Without rate limiting the backend is vulnerable to abuse, accidental request loops from the frontend, and unnecessary AI provider costs once /api/chat is implemented. This is a standard security baseline for any public API.
