### PR TITLE
fix: replace dynamic require() calls with es module imports

### DIFF
--- a/frontend/lib/moodData.ts
+++ b/frontend/lib/moodData.ts
@@ -1,3 +1,5 @@
+import { CustomMoodStorage } from './customMoods';
+
 export interface Mood {
   id: string;
   name: string;
@@ -2412,7 +2414,6 @@ export const MoodData = {
 
     // Then check custom moods
     if (typeof window !== "undefined") {
-      const { CustomMoodStorage } = require("./customMoods");
       const customMoods = CustomMoodStorage.getCustomMoods();
       return customMoods.find((mood: any) => mood.id === id) || null;
     }
@@ -2426,7 +2427,6 @@ export const MoodData = {
 
     // Get custom moods if in browser environment
     if (typeof window !== "undefined") {
-      const { CustomMoodStorage } = require("./customMoods");
       const customMoods = CustomMoodStorage.getCustomMoods();
       const allMoods = [...defaultMoods, ...customMoods];
 
@@ -2446,7 +2446,6 @@ export const MoodData = {
 
   getCustomMoods() {
     if (typeof window !== "undefined") {
-      const { CustomMoodStorage } = require("./customMoods");
       return CustomMoodStorage.getCustomMoods();
     }
     return [];


### PR DESCRIPTION
Closes #321 

## What This PR Does

Replaces three dynamic `require()` calls inside lib/moodData.ts with a single static ES module import at the top of the file.

## Root Cause

CustomMoodStorage was imported via require("./customMoods") inside three separate methods (getMoodById, getAllMoods, getCustomMoods) as a workaround to avoid SSR issues. However, the existing typeof window !== undefined guards inside each method already handle SSR safety — the dynamic `require() was never necessary and is inconsistent with
the ESM module system used throughout the project.

## Changes Made

- Removed three dynamic `require("./customMoods")` calls from getMoodById,  getAllMoods, and getCustomMoods
- Added a single static import { CustomMoodStorage } from './customMoods' at the top of the file
- Existing typeof window !== 'undefined' guards retained for SSR safety

## Testing

- App runs without errors on npm run dev
- Custom moods load correctly in browser 
- SSR renders without accessing localStorage 
- No TypeScript errors 

## Why This Matters

Using require() in an ESM TypeScript project bypasses static import analysis, prevents tree-shaking, and generates warnings in Node.js v22+. A static import is consistent with every other import in the codebase and allows TypeScript to properly analyse the module dependency.