### PR TITLE
fix(ci): add explicit permissions to docker jobs to fix ghcr push failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
     name: Docker Build & Test
     runs-on: ubuntu-latest
     needs: lint-and-audit
-    
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -148,7 +151,10 @@ jobs:
     needs: build-and-test-docker
     if: github.event_name != 'pull_request'
     continue-on-error: true
-    
+    permissions:
+      contents: read
+      packages: write
+      
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Closes #256

## What This PR Does

Adds explicit permissions blocks to the build-and-test-docker and security-scan jobs in .github/workflows/ci.yml to fix the GHCR push failure.

## Root Cause

The workflow had a top-level permissions block with packages: write, but GitHub Actions does not reliably propagate top-level permissions to individual jobs when using fine-grained tokens or GitHub App installations. The build-and-test-docker job was attempting to push to ghcr.io/nitya-003/innerhue:main without an explicit packages: write grant at the job level, causing:
## Changes Made

Added explicit permissions block to two jobs in ci.yml:

**`build-and-test-docker`**
```yaml
permissions:
  contents: read
  packages: write
```

**`security-scan`**
```yaml
permissions:
  contents: read
  packages: write
```

The top-level permissions block, docker/login-action registry config, and GITHUB_TOKEN usage were already correct — no other changes were needed.

## Testing

This fix can be verified by merging to main and observing the build-and-test-docker job successfully push toghcr.io/nitya-003/innerhue:main without the denied error.

## Why This Matters

The Docker publish pipeline has been broken since the workflow was introduced. Without this fix, no Docker images are ever pushed to GHCR, making the entire CI/CD publish pipeline non-functional.